### PR TITLE
Removed `.` from STORE_PATH env variable

### DIFF
--- a/src/content/docs/docker.mdx
+++ b/src/content/docs/docker.mdx
@@ -11,7 +11,7 @@ docker run -d \
   --restart always \
   -p 4983:4983 \
   -e PORT=4983 \ # Set the port for Drizzle Gateway (optional)
-  -e STORE_PATH=./app \ # Set your store path (optional)
+  -e STORE_PATH=/app \ # Set your store path (optional)
   -e MASTERPASS=your_master_password \ # Set your master pass (optional)
   -v drizzle-gateway:/app \
   ghcr.io/drizzle-team/gateway:latest


### PR DESCRIPTION
Sorry not sure why github edited the end line char. Happy to actually pull the repo and fix if you want.

Was wondering why this didnt work https://gateway.drizzle.team/docs/docker and noticed that its probably a difference in path and saw someone in discord with this config 
https://discord.com/channels/1043890932593987624/1255544000639668365/1445791216187871463